### PR TITLE
MediaTypeConfiguration

### DIFF
--- a/src/main/java/com/atipera/okushyn/testassignment/config/MediaTypeConfiguration.java
+++ b/src/main/java/com/atipera/okushyn/testassignment/config/MediaTypeConfiguration.java
@@ -1,0 +1,22 @@
+package com.atipera.okushyn.testassignment.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@EnableWebMvc
+public class MediaTypeConfiguration implements WebMvcConfigurer {
+
+    @Override
+    public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
+        configurer
+                .favorParameter(true)
+                .parameterName("mediaType")
+                .defaultContentType(MediaType.APPLICATION_JSON) // Set the default media type
+                .mediaType("json", MediaType.APPLICATION_JSON)   // Map "json" to JSON
+                .mediaType("xml", MediaType.APPLICATION_XML);     // Map "xml" to XML
+    }
+}


### PR DESCRIPTION
MediaTypeConfiguration - for setting up application/jason media type by default or mapping to xml if "xml" param is received